### PR TITLE
Use HTML template for digest emails

### DIFF
--- a/email_template.html
+++ b/email_template.html
@@ -1,0 +1,103 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+<title>Hansard Monitor Template</title>
+</head>
+<body>
+<div class="WordSection1">
+<div align="center">
+<table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="891">
+ <tr>
+  <td>
+   <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="900" style="background:white;">
+    <tr>
+     <td>
+      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#475560;">
+       <tr>
+        <td style="padding:18.0pt 21.0pt 18.0pt 21.0pt">
+         <p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:20.0pt;font-family:'Segoe UI',sans-serif;color:white">Hansard Monitor   BETA Version 18.3</span></b></p>
+         <p class="MsoNormal" align="center" style="text-align:center"><span style="font-size:12.0pt;font-family:'Segoe UI',sans-serif;color:white">Program Run: [DATE]</span></p>
+        </td>
+       </tr>
+      </table>
+      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#ECF0F1;">
+       <tr>
+        <td style="padding:0cm 12.0pt 0cm 12.0pt">
+         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="background:white;border:solid #D8DCE0 1.0pt;">
+          <tr>
+           <td style="border-bottom:solid #C5A572 2.25pt;padding:12.0pt 13.5pt 12.0pt 13.5pt">
+            <p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:12.0pt;color:black">Detection Match by Chamber</span></b></p>
+           </td>
+          </tr>
+          <tr>
+           <td style="padding:9.0pt 12.0pt 9.0pt 12.0pt">
+            <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="background:white;border-collapse:collapse;">
+             <tr>
+              <td width="28%" style="background:#4A5A6A;padding:9.0pt 7.5pt 9.0pt 7.5pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Keyword</span></b></p></td>
+              <td width="28%" style="background:#4A5A6A;padding:9.0pt 7.5pt 9.0pt 7.5pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">House of Assembly</span></b></p></td>
+              <td width="28%" style="background:#4A5A6A;padding:9.0pt 7.5pt 9.0pt 7.5pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Legislative Council</span></b></p></td>
+              <td width="15%" style="background:#4A5A6A;padding:9.0pt 7.5pt 9.0pt 7.5pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Total</span></b></p></td>
+             </tr>
+             <tr>
+              <td width="28%" style="border-top:none;border-left:solid #D8DCE0 1.0pt;border-bottom:solid #ECF0F1 1.0pt;border-right:none;padding:6.0pt 7.5pt 6.0pt 7.5pt"><p class="MsoNormal"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">pokies</span></b></p></td>
+              <td width="28%" style="border-bottom:solid #ECF0F1 1.0pt;padding:6.0pt 7.5pt 6.0pt 7.5pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">3</span></b></p></td>
+              <td width="28%" style="border-bottom:solid #ECF0F1 1.0pt;padding:6.0pt 7.5pt 6.0pt 7.5pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">0</span></b></p></td>
+              <td width="15%" style="border-bottom:solid #ECF0F1 1.0pt;border-right:solid #D8DCE0 1.0pt;padding:6.0pt 7.5pt 6.0pt 7.5pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">3</span></b></p></td>
+             </tr>
+            </table>
+           </td>
+          </tr>
+         </table>
+        </td>
+       </tr>
+      </table>
+      <!-- Sample section to be replaced -->
+      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="100%">
+       <tr>
+        <td style="border:none;border-left:solid #C5A572 3.0pt;background:#F7F9FA;padding:9.0pt 10.5pt 9.0pt 10.5pt">
+         <p class="MsoNormal"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">Sample_File.txt</span></b></p>
+         <p class="MsoNormal"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">1 match(es)</span></p>
+        </td>
+       </tr>
+       <tr>
+        <td style="border:solid #D8DCE0 1.0pt;border-top:none;background:white;padding:7.5pt 9.0pt 7.5pt 9.0pt">
+         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="border:solid #D8DCE0 1.0pt;">
+          <tr>
+           <td style="border:none;border-bottom:solid #D8DCE0 1.0pt;background:#ECF0F1;padding:7.5pt 9.0pt 7.5pt 9.0pt">
+            <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="100%">
+             <tr style="height:24.0pt">
+              <td width="32" style="background:#4A5A6A;height:24.0pt"><p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">1</span></b></p></td>
+              <td style="padding:0cm 0cm 0cm 9.0pt;height:24.0pt"><p class="MsoNormal"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif">Speaker</span></b></p></td>
+              <td style="height:24.0pt" align="right"><p class="MsoNormal" style="text-align:right"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif">line 1</span></p></td>
+             </tr>
+            </table>
+           </td>
+          </tr>
+          <tr>
+           <td style="padding:10.5pt 12.0pt 10.5pt 12.0pt">
+            <p class="MsoNormal"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif">Excerpt with <b><span style="background:lightgrey">keyword</span></b>.</span></p>
+           </td>
+          </tr>
+         </table>
+        </td>
+       </tr>
+      </table>
+      <!-- End sample section -->
+      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#4A5A6A;">
+       <tr>
+        <td style="padding:12.0pt 12.0pt 12.0pt 12.0pt">
+         <p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">**THIS PROGRAM IS IN BETA TESTING   DO NOT FORWARD**</span></b></p>
+         <p class="MsoNormal" align="center" style="text-align:center"><span style="font-size:9.0pt;font-family:'Segoe UI',sans-serif;color:white">Contact developer with any issues, queries, or suggestions: William.Manning@FederalGroup.com.au</span></p>
+        </td>
+       </tr>
+      </table>
+     </td>
+    </tr>
+   </table>
+  </td>
+ </tr>
+</table>
+</div>
+</div>
+</body>
+</html>

--- a/send_email.py
+++ b/send_email.py
@@ -17,11 +17,10 @@ FIRST_SENT_FOLLOWING = 2  # for first-sentence hits: include next two sentences
 MERGE_IF_GAP_GT = 2       # Only merge windows if the gap (in sentences) is > this value
 
 # --- Template inputs ---------------------------------------------------------
-# Point to your uploaded Outlook/Word HTML template
-TEMPLATE_HTML_PATH = Path(os.environ.get(
-    "TEMPLATE_HTML_PATH",
-    "Hansard Monitor - Email Format - Version 3.htm"
-))
+# Point to the bundled Outlook/Word HTML template (can be overridden via env)
+TEMPLATE_HTML_PATH = Path(
+    os.environ.get("TEMPLATE_HTML_PATH", "email_template.html")
+)
 DEFAULT_TITLE = "Hansard Monitor – BETA Version 18.3"
 
 # --- Helpers -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- bundle Word-style HTML template and reference it by default
- load template path from environment or bundled file in send_email.py

## Testing
- `python -m py_compile send_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7dafd58b08332bcb5156941c876af