### PR TITLE
Ensure consistent UTF-8 encoding and verify HTML send

### DIFF
--- a/tests/test_send_email.py
+++ b/tests/test_send_email.py
@@ -1,6 +1,8 @@
+import os
 import unittest
 from pathlib import Path
 from unittest import mock
+from html.parser import HTMLParser
 import tempfile
 import send_email
 
@@ -20,27 +22,17 @@ class MergeWindowsTest(unittest.TestCase):
 
 class TemplateDecodeTest(unittest.TestCase):
     def test_decoding_error_raises(self):
-        class Bad:
-            def decode(self, *args, **kwargs):
-                raise UnicodeDecodeError("test", b"", 0, 1, "bad")
-
         class DummyPath:
             def read_bytes(self):
-                return Bad()
+                return b"\xff"
 
         with self.assertRaises(RuntimeError):
             send_email._load_template_text(DummyPath())
 
-    def test_utf8_fallback(self):
-        class Fake:
-            def decode(self, encoding, errors="strict"):
-                if encoding == "windows-1252":
-                    raise UnicodeDecodeError("test", b"", 0, 1, "bad")
-                return "ok"
-
+    def test_decodes_with_chosen_encoding(self):
         class DummyPath:
             def read_bytes(self):
-                return Fake()
+                return "ok".encode(send_email.ENCODING)
 
         self.assertEqual(send_email._load_template_text(DummyPath()), "ok")
 
@@ -49,10 +41,62 @@ class EncodingIntegrationTest(unittest.TestCase):
     def test_dash_preserved(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = Path(tmp) / "House_of_Assembly_test.txt"
-            transcript.write_text("Mr SPEAKER:\n dash – test dash.", encoding="utf-8")
+            transcript.write_text("Mr SPEAKER:\n dash – test dash.", encoding=send_email.ENCODING)
             html, _total, _counts = send_email.build_digest_html([str(transcript)], ["dash"])
-            self.assertIn("charset=utf-8", html)
+            self.assertIn(f"charset={send_email.ENCODING}", html)
             self.assertTrue("–" in html, "dash missing")
+
+
+class SendEmailIntegrationTest(unittest.TestCase):
+    def test_yagmail_receives_encoded_html(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                Path("transcripts").mkdir()
+                transcript = Path("transcripts") / "House_of_Assembly_test.txt"
+                transcript.write_text("Mr SPEAKER:\n dash – test dash.", encoding=send_email.ENCODING)
+
+                env = {
+                    "EMAIL_USER": "u",
+                    "EMAIL_PASS": "p",
+                    "EMAIL_TO": "t@example.com",
+                    "KEYWORDS": "dash",
+                }
+                captured = {}
+
+                class DummySMTP:
+                    def __init__(self, *args, **kwargs):
+                        pass
+
+                    def send(self, **kwargs):
+                        captured.update(kwargs)
+
+                with mock.patch.dict(os.environ, env, clear=True), mock.patch(
+                    "send_email.yagmail.SMTP", return_value=DummySMTP()
+                ):
+                    send_email.main()
+
+                self.assertIn("contents", captured)
+                content = captured["contents"][0]
+                self.assertIsInstance(content, bytes)
+                html = content.decode(send_email.ENCODING)
+
+                class Collector(HTMLParser):
+                    def __init__(self):
+                        super().__init__()
+                        self.text = []
+
+                    def handle_data(self, data):
+                        self.text.append(data)
+
+                parser = Collector()
+                parser.feed(html)
+                text = "".join(parser.text)
+                self.assertIn("–", text)
+                self.assertIn(f"charset={send_email.ENCODING}", html)
+            finally:
+                os.chdir(cwd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use a single UTF-8 encoding across email generation
- encode email HTML before sending via yagmail
- add integration test that ensures special characters survive the send

## Testing
- `python -m pytest tests/test_send_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8fae4d9b483329bbe5f284e2dda8a