### PR TITLE
Improve email template spacing and encoding

### DIFF
--- a/email_template.html
+++ b/email_template.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>Hansard Monitor Template</title>
 </head>
 <body>
@@ -16,57 +16,52 @@
       <!-- HEADER -->
       <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#475560;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;" align="center">
        <tr>
-        <td style="padding:18.0pt 21.0pt 18.0pt 21.0pt">
+        <td style="padding:24px 28px 40px 28px">
          <p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:20.0pt;font-family:'Segoe UI',sans-serif;color:white">Hansard Monitor – BETA Version 18.3</span></b></p>
          <p class="MsoNormal" align="center" style="text-align:center"><span style="font-size:12.0pt;font-family:'Segoe UI',sans-serif;color:white">Program Run: [DATE]</span></p>
         </td>
        </tr>
       </table>
 
-      <!-- SPACER -->
-      <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="91%" align="center">
-       <tr><td style="height:10.0pt;line-height:10.0pt;font-size:0;">&nbsp;</td></tr>
-      </table>
-
       <!-- DETECTION SUMMARY WRAPPER -->
       <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#ECF0F1;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;" align="center">
        <tr>
-        <td style="padding:12.0pt 12.0pt 12.0pt 12.0pt">
+        <td style="padding:16px">
          <!-- DETECTION_SUMMARY_TABLE_START -->
-         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="background:white;border:solid #D8DCE0 1.0pt;border-collapse:collapse;">
+         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="background:white;border:solid #D8DCE0 1px;border-collapse:collapse;">
           <tr>
-           <td style="border-bottom:solid #C5A572 2.25pt;padding:12.0pt 16.0pt 12.0pt 16.0pt">
+           <td style="border-bottom:solid #C5A572 3px;padding:16px 21px 16px 21px">
             <p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:12.0pt;color:black">Detection Match by Chamber</span></b></p>
            </td>
           </tr>
           <tr>
-           <td style="padding:10.0pt 12.0pt 10.0pt 12.0pt">
+           <td style="padding:13px 16px 13px 16px">
             <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="background:white;border-collapse:collapse;">
              <tr>
-              <td width="28%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
+              <td width="28%" style="background:#4A5A6A;padding:11px 13px 11px 13px">
                 <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Keyword</span></b></p>
               </td>
-              <td width="28%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
+              <td width="28%" style="background:#4A5A6A;padding:11px 13px 11px 13px">
                 <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">House of Assembly</span></b></p>
               </td>
-              <td width="28%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
+              <td width="28%" style="background:#4A5A6A;padding:11px 13px 11px 13px">
                 <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Legislative Council</span></b></p>
               </td>
-              <td width="15%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
+              <td width="15%" style="background:#4A5A6A;padding:11px 13px 11px 13px">
                 <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Total</span></b></p>
               </td>
              </tr>
              <tr>
-              <td width="28%" style="border-top:none;border-left:solid #D8DCE0 1.0pt;border-bottom:solid #ECF0F1 1.0pt;border-right:none;padding:7.5pt 10.0pt 7.5pt 10.0pt">
+              <td width="28%" style="border-top:none;border-left:solid #D8DCE0 1px;border-bottom:solid #ECF0F1 1px;border-right:none;padding:10px 13px 10px 13px">
                 <p class="MsoNormal" style="margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">pokies</span></b></p>
               </td>
-              <td width="28%" style="border-bottom:solid #ECF0F1 1.0pt;padding:7.5pt 10.0pt 7.5pt 10.0pt">
+              <td width="28%" style="border-bottom:solid #ECF0F1 1px;padding:10px 13px 10px 13px">
                 <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">3</span></b></p>
               </td>
-              <td width="28%" style="border-bottom:solid #ECF0F1 1.0pt;padding:7.5pt 10.0pt 7.5pt 10.0pt">
+              <td width="28%" style="border-bottom:solid #ECF0F1 1px;padding:10px 13px 10px 13px">
                 <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">0</span></b></p>
               </td>
-              <td width="15%" style="border-bottom:solid #ECF0F1 1.0pt;border-right:solid #D8DCE0 1.0pt;padding:7.5pt 10.0pt 7.5pt 10.0pt">
+              <td width="15%" style="border-bottom:solid #ECF0F1 1px;border-right:solid #D8DCE0 1px;padding:10px 13px 10px 13px">
                 <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">3</span></b></p>
               </td>
              </tr>
@@ -81,34 +76,36 @@
 
       <!-- SPACER -->
       <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="91%" align="center">
-       <tr><td style="height:10.0pt;line-height:10.0pt;font-size:0;">&nbsp;</td></tr>
+       <tr>
+        <td height="16" style="height:16px;line-height:16px;font-size:0;mso-line-height-rule:exactly;">&nbsp;</td>
+       </tr>
       </table>
 
       <!-- Sample section to be replaced -->
       <!-- SAMPLE_SECTION_START -->
       <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" align="center" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
        <tr>
-        <td style="border:none;border-left:solid #C5A572 3.0pt;background:#F7F9FA;padding:10.5pt 12.0pt 10.5pt 12.0pt">
-         <p class="MsoNormal" style="margin:0 0 2pt 0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">Sample_File.txt</span></b></p>
+        <td style="border:none;border-left:solid #C5A572 4px;background:#F7F9FA;padding:14px 16px 14px 16px">
+         <p class="MsoNormal" style="margin:0 0 2px 0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">Sample_File.txt</span></b></p>
          <p class="MsoNormal" style="margin:0;"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">1 match(es)</span></p>
         </td>
        </tr>
        <tr>
-        <td style="border:solid #D8DCE0 1.0pt;border-top:none;background:white;padding:9.0pt 10.5pt 9.0pt 10.5pt">
-         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="border:solid #D8DCE0 1.0pt;border-collapse:collapse;">
+        <td style="border:solid #D8DCE0 1px;border-top:none;background:white;padding:12px 14px 12px 14px">
+         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="border:solid #D8DCE0 1px;border-collapse:collapse;">
           <tr>
-           <td style="border:none;border-bottom:solid #D8DCE0 1.0pt;background:#ECF0F1;padding:7.5pt 9.0pt 7.5pt 9.0pt">
+           <td style="border:none;border-bottom:solid #D8DCE0 1px;background:#ECF0F1;padding:10px 12px 10px 12px">
             <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="100%" style="border-collapse:collapse;">
-             <tr style="height:24.0pt">
+             <tr height="32" style="height:32px">
               <!-- NUMBER BADGE: dark slate, no border -->
-              <td width="32" style="background:#4A5A6A;height:24.0pt;border:0;mso-border-alt:none;line-height:24.0pt;">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;line-height:24.0pt;mso-line-height-rule:exactly;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">1</span></b></p>
+              <td width="32" height="32" style="background:#4A5A6A;height:32px;border:0;mso-border-alt:none;line-height:32px;">
+                <p class="MsoNormal" align="center" style="text-align:center;margin:0;line-height:32px;mso-line-height-rule:exactly;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">1</span></b></p>
               </td>
-              <td style="padding:0 0 0 9.0pt;height:24.0pt">
+              <td height="32" style="padding:0 0 0 12px;height:32px">
                 <!-- SPEAKER: force uppercase rendering -->
                 <p class="MsoNormal" style="margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;text-transform:uppercase;">Speaker</span></b></p>
               </td>
-              <td style="height:24.0pt" align="right">
+              <td height="32" style="height:32px" align="right">
                 <p class="MsoNormal" style="text-align:right;margin:0;"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif">line 1</span></p>
               </td>
              </tr>
@@ -116,7 +113,7 @@
            </td>
           </tr>
           <tr>
-           <td style="padding:12.0pt 12.0pt 12.0pt 12.0pt">
+           <td style="padding:16px">
             <!-- KEYWORD HIGHLIGHT: bold + light grey background -->
             <p class="MsoNormal" style="margin:0;"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif">Excerpt with <b><span style="background:lightgrey">keyword</span></b>.</span></p>
            </td>
@@ -128,15 +125,10 @@
       <!-- SAMPLE_SECTION_END -->
       <!-- End sample section -->
 
-      <!-- SPACER -->
-      <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="91%" align="center">
-       <tr><td style="height:10.0pt;line-height:10.0pt;font-size:0;">&nbsp;</td></tr>
-      </table>
-
       <!-- FOOTER -->
       <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#4A5A6A;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;" align="center">
        <tr>
-        <td style="padding:12.0pt 12.0pt 12.0pt 12.0pt">
+        <td style="padding:32px 16px 16px 16px">
          <p class="MsoNormal" align="center" style="text-align:center;margin:0 0 3pt 0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">**THIS PROGRAM IS IN BETA TESTING – DO NOT FORWARD**</span></b></p>
          <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><span style="font-size:9.0pt;font-family:'Segoe UI',sans-serif;color:white">Contact developer with any issues, queries, or suggestions: William.Manning@FederalGroup.com.au</span></p>
         </td>

--- a/send_email.py
+++ b/send_email.py
@@ -306,8 +306,9 @@ def _tighten_outlook_whitespace(html: str) -> str:
     html = re.sub(r"(?:\s*<br[^>]*>\s*){2,}", "<br>", html, flags=re.I)
     # 3) Remove whitespace/comments between adjacent tables
     html = re.sub(r"(</table>)\s+(?=(?:<!--.*?-->\s*)*<table\b)", r"\1", html, flags=re.I | re.S)
-    # 4) Trim blank space just inside table cells
-    html = re.sub(r">\s*(?:&nbsp;|<br[^>]*>|\s)+</td>", "></td>", html, flags=re.I)
+    # 4) Trim blank space just inside table cells but preserve non-breaking spaces
+    html = re.sub(r">\s*&nbsp;\s*</td>", ">&nbsp;</td>", html, flags=re.I)
+    html = re.sub(r">\s*(?:<br[^>]*>|\s)+</td>", "></td>", html, flags=re.I)
     return html
 
 def _minify_inter_tag_whitespace(html: str) -> str:


### PR DESCRIPTION
## Summary
- switch email template to UTF-8 and replace fragile pt-based spacing with pixel values
- add bulletproof spacer cell and adjust footer/header padding
- keep non-breaking spaces during HTML cleanup

## Testing
- `python3 <<'PY'
import sys, types, unittest
sys.modules['yagmail'] = types.SimpleNamespace(SMTP=object)
import tests.test_send_email as t
unittest.main(t, argv=[''], exit=False)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b9043a51f48332a2e58571a7b9c08a