### PR TITLE
refactor: replace spacer rows with bulletproof cells

### DIFF
--- a/email_template.html
+++ b/email_template.html
@@ -29,19 +29,17 @@
     .lh-tight{line-height:16px}
     .lh-base{line-height:18px}
     .lh-loose{line-height:22px}
-    .small{font-size:10pt}
-    .base{font-size:11pt}
-    .lg{font-size:12pt}
-    .xl{font-size:20pt}
+    .small{font-size:13px}
+    .base{font-size:15px}
+    .lg{font-size:16px}
+    .xl{font-size:27px}
     .tbl-hdr{background:#4A5A6A;color:#FFFFFF}
     .tbl-cell{border-bottom:1px solid #ECF0F1}
     .tbl-left{border-left:1px solid #D8DCE0}
     .tbl-right{border-right:1px solid #D8DCE0}
     .num{font-weight:700;color:#000;text-align:center}
     .kw{font-weight:700;color:#000}
-    .spacer-2{height:2px;line-height:2px;font-size:0}
-    .spacer-6{height:6px;line-height:6px;font-size:0}
-    .badge{background:#4A5A6A;color:#FFF;font-weight:700;font-size:10pt;height:18px;line-height:18px;display:inline-block;text-align:center;width:32px}
+    .badge{background:#4A5A6A;color:#FFF;font-weight:700;font-size:13px;height:18px;line-height:18px;display:inline-block;text-align:center;width:32px}
     .card-hdr{background:#ECF0F1;border-bottom:1px solid #D8DCE0}
     .section-rail{border-left:3px solid #C5A572;background:#F7F9FA}
     /* Make paragraphs tight in Outlook as well; Python also injects an MSO reset */
@@ -68,13 +66,12 @@
             </tr>
           </table>
 
-          <div class="spacer-6">&nbsp;</div>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td height="6" style="height:6px;line-height:6px;font-size:0;mso-line-height-rule:exactly;">&nbsp;</td></tr></table>
 
           <!-- Detection panel -->
           <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="panel">
             <tr>
-              <td class="pad-0">
-                <div class="spacer-6">&nbsp;</div>
+              <td class="pad-0" style="padding:6px 0;">
                 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="panel-inner">
                   <!-- Section heading -->
                   <tr>
@@ -106,12 +103,11 @@
                     </td>
                   </tr>
                 </table>
-                <div class="spacer-6">&nbsp;</div>
               </td>
             </tr>
           </table>
 
-          <div class="spacer-6">&nbsp;</div>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td height="6" style="height:6px;line-height:6px;font-size:0;mso-line-height-rule:exactly;">&nbsp;</td></tr></table>
 
           <!-- Sample section to be replaced (Python removes this block entirely) -->
           <!-- Sample section to be replaced -->
@@ -140,7 +136,7 @@
                       </tr>
                     </table>
 
-                    <div class="spacer-2">&nbsp;</div>
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td height="2" style="height:2px;line-height:2px;font-size:0;mso-line-height-rule:exactly;">&nbsp;</td></tr></table>
                   </td>
                 </tr>
               </table>
@@ -148,7 +144,7 @@
           </table>
           <!-- End sample section -->
 
-          <div class="spacer-6">&nbsp;</div>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td height="6" style="height:6px;line-height:6px;font-size:0;mso-line-height-rule:exactly;">&nbsp;</td></tr></table>
 
         </td></tr>
       </table>


### PR DESCRIPTION
## Summary
- replace spacer divs with bullet-proof spacer tables
- convert font sizes to pixel units and pad detection panel

## Testing
- `python -m pytest -q` *(fails: No module named 'torch')*
- `pip install torch --quiet` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68b907d2b89c8332a6a1a6d0a8522f5e