### PR TITLE
Overhaul email digest template

### DIFF
--- a/email_template.html
+++ b/email_template.html
@@ -1,151 +1,33 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
-<title>Hansard Monitor Template</title>
+<meta charset="utf-8">
+<title>Hansard Monitor Digest</title>
+<style>
+body{font-family:Segoe UI,Arial,sans-serif;background:#ffffff;color:#000;margin:0;padding:20px;}
+h1{font-size:20px;margin:0 0 10px;}
+table{border-collapse:collapse;width:100%;margin-bottom:20px;}
+th,td{border:1px solid #ddd;padding:6px 8px;font-size:13px;}
+th{background:#f0f0f0;text-align:left;}
+.section{margin-bottom:24px;}
+.match{margin:12px 0;}
+.meta{font-size:12px;color:#555;}
+.excerpt{font-size:13px;line-height:1.4;}
+</style>
 </head>
 <body>
-<div class="WordSection1">
-<div align="center">
-<table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="900" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
- <tr>
-  <td>
-   <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="900" style="background:white;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
-    <tr>
-     <td>
-
-      <!-- HEADER -->
-      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#475560;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;" align="center">
-       <tr>
-        <td style="padding:18.0pt 21.0pt 18.0pt 21.0pt">
-         <p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:20.0pt;font-family:'Segoe UI',sans-serif;color:white">Hansard Monitor – BETA Version 18.3</span></b></p>
-         <p class="MsoNormal" align="center" style="text-align:center"><span style="font-size:12.0pt;font-family:'Segoe UI',sans-serif;color:white">Program Run: [DATE]</span></p>
-        </td>
-       </tr>
-      </table>
-
-      <!-- SPACER -->
-      <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="91%" align="center">
-       <tr><td style="height:10.0pt;line-height:10.0pt;font-size:0;">&nbsp;</td></tr>
-      </table>
-
-      <!-- DETECTION SUMMARY WRAPPER -->
-      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#ECF0F1;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;" align="center">
-       <tr>
-        <td style="padding:12.0pt 12.0pt 12.0pt 12.0pt">
-         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="background:white;border:solid #D8DCE0 1.0pt;border-collapse:collapse;">
-          <tr>
-           <td style="border-bottom:solid #C5A572 2.25pt;padding:12.0pt 16.0pt 12.0pt 16.0pt">
-            <p class="MsoNormal" align="center" style="text-align:center"><b><span style="font-size:12.0pt;color:black">Detection Match by Chamber</span></b></p>
-           </td>
-          </tr>
-          <tr>
-           <td style="padding:10.0pt 12.0pt 10.0pt 12.0pt">
-            <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="background:white;border-collapse:collapse;">
-             <tr>
-              <td width="28%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Keyword</span></b></p>
-              </td>
-              <td width="28%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">House of Assembly</span></b></p>
-              </td>
-              <td width="28%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Legislative Council</span></b></p>
-              </td>
-              <td width="15%" style="background:#4A5A6A;padding:8.0pt 10.0pt 8.0pt 10.0pt">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">Total</span></b></p>
-              </td>
-             </tr>
-             <tr>
-              <td width="28%" style="border-top:none;border-left:solid #D8DCE0 1.0pt;border-bottom:solid #ECF0F1 1.0pt;border-right:none;padding:7.5pt 10.0pt 7.5pt 10.0pt">
-                <p class="MsoNormal" style="margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">pokies</span></b></p>
-              </td>
-              <td width="28%" style="border-bottom:solid #ECF0F1 1.0pt;padding:7.5pt 10.0pt 7.5pt 10.0pt">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">3</span></b></p>
-              </td>
-              <td width="28%" style="border-bottom:solid #ECF0F1 1.0pt;padding:7.5pt 10.0pt 7.5pt 10.0pt">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">0</span></b></p>
-              </td>
-              <td width="15%" style="border-bottom:solid #ECF0F1 1.0pt;border-right:solid #D8DCE0 1.0pt;padding:7.5pt 10.0pt 7.5pt 10.0pt">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">3</span></b></p>
-              </td>
-             </tr>
-            </table>
-           </td>
-          </tr>
-         </table>
-        </td>
-       </tr>
-      </table>
-
-      <!-- SPACER -->
-      <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="91%" align="center">
-       <tr><td style="height:10.0pt;line-height:10.0pt;font-size:0;">&nbsp;</td></tr>
-      </table>
-
-      <!-- Sample section to be replaced -->
-      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" align="center" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
-       <tr>
-        <td style="border:none;border-left:solid #C5A572 3.0pt;background:#F7F9FA;padding:10.5pt 12.0pt 10.5pt 12.0pt">
-         <p class="MsoNormal" style="margin:0 0 2pt 0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">Sample_File.txt</span></b></p>
-         <p class="MsoNormal" style="margin:0;"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:black">1 match(es)</span></p>
-        </td>
-       </tr>
-       <tr>
-        <td style="border:solid #D8DCE0 1.0pt;border-top:none;background:white;padding:9.0pt 10.5pt 9.0pt 10.5pt">
-         <table class="MsoNormalTable" border="1" cellspacing="0" cellpadding="0" width="100%" style="border:solid #D8DCE0 1.0pt;border-collapse:collapse;">
-          <tr>
-           <td style="border:none;border-bottom:solid #D8DCE0 1.0pt;background:#ECF0F1;padding:7.5pt 9.0pt 7.5pt 9.0pt">
-            <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="100%" style="border-collapse:collapse;">
-             <tr style="height:24.0pt">
-              <!-- NUMBER BADGE: dark slate, no border -->
-              <td width="32" style="background:#4A5A6A;height:24.0pt;border:0;mso-border-alt:none;line-height:24.0pt;">
-                <p class="MsoNormal" align="center" style="text-align:center;margin:0;line-height:24.0pt;mso-line-height-rule:exactly;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">1</span></b></p>
-              </td>
-              <td style="padding:0 0 0 9.0pt;height:24.0pt">
-                <!-- SPEAKER: force uppercase rendering -->
-                <p class="MsoNormal" style="margin:0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;text-transform:uppercase;">Speaker</span></b></p>
-              </td>
-              <td style="height:24.0pt" align="right">
-                <p class="MsoNormal" style="text-align:right;margin:0;"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif">line 1</span></p>
-              </td>
-             </tr>
-            </table>
-           </td>
-          </tr>
-          <tr>
-           <td style="padding:12.0pt 12.0pt 12.0pt 12.0pt">
-            <!-- KEYWORD HIGHLIGHT: bold + light grey background -->
-            <p class="MsoNormal" style="margin:0;"><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif">Excerpt with <b><span style="background:lightgrey">keyword</span></b>.</span></p>
-           </td>
-          </tr>
-         </table>
-        </td>
-       </tr>
-      </table>
-      <!-- End sample section -->
-
-      <!-- SPACER -->
-      <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="91%" align="center">
-       <tr><td style="height:10.0pt;line-height:10.0pt;font-size:0;">&nbsp;</td></tr>
-      </table>
-
-      <!-- FOOTER -->
-      <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="91%" style="background:#4A5A6A;border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;" align="center">
-       <tr>
-        <td style="padding:12.0pt 12.0pt 12.0pt 12.0pt">
-         <p class="MsoNormal" align="center" style="text-align:center;margin:0 0 3pt 0;"><b><span style="font-size:10.0pt;font-family:'Segoe UI',sans-serif;color:white">**THIS PROGRAM IS IN BETA TESTING – DO NOT FORWARD**</span></b></p>
-         <p class="MsoNormal" align="center" style="text-align:center;margin:0;"><span style="font-size:9.0pt;font-family:'Segoe UI',sans-serif;color:white">Contact developer with any issues, queries, or suggestions: William.Manning@FederalGroup.com.au</span></p>
-        </td>
-       </tr>
-      </table>
-
-     </td>
-    </tr>
-   </table>
-  </td>
- </tr>
+<h1>Hansard Monitor – BETA Version 18.3</h1>
+<p>[DATE]</p>
+<table>
+<thead>
+<tr><th>Keyword</th><th>House of Assembly</th><th>Legislative Council</th><th>Total</th></tr>
+</thead>
+<tbody>
+[DETECTION_ROWS]
+</tbody>
 </table>
-</div>
+<div id="sections">
+[SECTIONS]
 </div>
 </body>
 </html>

--- a/send_email.py
+++ b/send_email.py
@@ -14,46 +14,20 @@ import yagmail
 # =============================================================================
 
 def _resolve_template_path() -> Path:
-    # 1) Allow env override
     env_path = os.environ.get("TEMPLATE_HTML_PATH")
     if env_path:
         p = Path(env_path)
         if p.exists():
             return p
 
-    # 2) Common names (what you've used)
     script_dir = Path(__file__).resolve().parent
-    candidates = [
-        "email_template.html",
-        "email_template.htm",
-        "email_template (1).html",
-        "email_template (1).htm",
-        "Hansard Monitor - Email Format - Version 3.htm",
-        "Hansard Monitor - Email Format - Version 3.html",
-        "templates/email_template.html",
-        "templates/email_template.htm",
-        "templates/email_template (1).html",
-        "templates/email_template (1).htm",
-        "templates/Hansard Monitor - Email Format - Version 3.htm",
-        "templates/Hansard Monitor - Email Format - Version 3.html",
-    ]
-    for name in candidates:
+    for name in ["email_template.html", "templates/email_template.html"]:
         p = script_dir / name
         if p.exists():
             return p
 
-    # 3) Fallback: find any plausible .htm(l)
-    for pat in ("**/*.htm", "**/*.html"):
-        for fp in script_dir.glob(pat):
-            if any(k in fp.name.lower() for k in ("email", "template", "hansard", "format")):
-                return fp
-    for pat in ("**/*.htm", "**/*.html"):
-        for fp in script_dir.glob(pat):
-            return fp
-
     raise FileNotFoundError(
-        "HTML template not found. Set TEMPLATE_HTML_PATH or place the template "
-        "next to send_email.py (e.g., 'Hansard Monitor - Email Format - Version 3.htm')."
+        "HTML template not found. Set TEMPLATE_HTML_PATH or place 'email_template.html' next to send_email.py."
     )
 
 TEMPLATE_HTML_PATH = _resolve_template_path()
@@ -288,176 +262,44 @@ def extract_matches(text: str, keywords):
             results.append((set(kws_in_excerpt), excerpt_html, speaker, line_list, win_start, win_end))
     return results
 
-# =============================================================================
-# Outlook/Gmail whitespace fixes
-# =============================================================================
-
-_EMPTY_MSOP_RE = re.compile(
-    r"<p\b[^>]*>(?:\s|&nbsp;|<br[^>]*>|"
-    r"<o:p>\s*&nbsp;\s*</o:p>|"
-    r"<span\b[^>]*>(?:\s|&nbsp;|<br[^>]*>)*</span>)*</p>",
-    re.I,
-)
-
-def _tighten_outlook_whitespace(html: str) -> str:
-    # 1) Remove empty Word/Outlook paragraphs (even if wrapped)
-    html = _EMPTY_MSOP_RE.sub("", html)
-    # 2) Collapse runs of <br> to a single <br>
-    html = re.sub(r"(?:\s*<br[^>]*>\s*){2,}", "<br>", html, flags=re.I)
-    # 3) Remove whitespace/comments between adjacent tables
-    html = re.sub(r"(</table>)\s+(?=(?:<!--.*?-->\s*)*<table\b)", r"\1", html, flags=re.I | re.S)
-    # 4) Trim blank space just inside table cells
-    html = re.sub(r">\s*(?:&nbsp;|<br[^>]*>|\s)+</td>", "></td>", html, flags=re.I)
-    return html
-
-def _minify_inter_tag_whitespace(html: str) -> str:
-    # Critical for Outlook: remove inter-tag newlines/indentation
-    return re.sub(r">\s+<", "><", html)
-
-def _inject_mso_css_reset(html: str) -> str:
-    # MSO conditional CSS to kill default MsoNormal margins/line-height
-    mso_block = (
-        "<!--[if mso]>"
-        "<style>"
-        "p.MsoNormal,div.MsoNormal,li.MsoNormal{margin:0 !important;line-height:normal !important;}"
-        "table,td{mso-table-lspace:0pt !important;mso-table-rspace:0pt !important;mso-line-height-rule:exactly !important;}"
-        "</style>"
-        "<![endif]-->"
-    )
-    # Insert before </head> if possible; else prepend
-    if re.search(r"</head\s*>", html, re.I):
-        return re.sub(r"</head\s*>", mso_block + "</head>", html, flags=re.I, count=1)
-    return mso_block + html
 
 # =============================================================================
-# Template operations (summary & sections)
+# Digest assembly helpers
 # =============================================================================
 
-def _build_detection_row(kw, hoa, lc, tot) -> str:
-    # Use pixel paddings; margin:0 paragraphs
+def _build_detection_row(kw: str, hoa: int, lc: int, tot: int) -> str:
+    esc = _html_escape
     return (
         "<tr>"
-        "<td width=\"28%\" style='border-top:none;border-left:solid #D8DCE0 1px;border-bottom:solid #ECF0F1 1px;border-right:none;padding:8px 10px;'>"
-        f"<p class=MsoNormal style='margin:0;'><b><span style='font-size:10pt;font-family:\"Segoe UI\",sans-serif;color:black'>{_html_escape(kw)}</span></b></p></td>"
-        "<td width=\"28%\" style='border-bottom:solid #ECF0F1 1px;padding:8px 10px;'>"
-        f"<p class=MsoNormal align=center style='text-align:center;margin:0;'><b><span style='font-size:10pt;font-family:\"Segoe UI\",sans-serif;color:black'>{hoa}</span></b></p></td>"
-        "<td width=\"28%\" style='border-bottom:solid #ECF0F1 1px;padding:8px 10px;'>"
-        f"<p class=MsoNormal align=center style='text-align:center;margin:0;'><b><span style='font-size:10pt;font-family:\"Segoe UI\",sans-serif;color:black'>{lc}</span></b></p></td>"
-        "<td width=\"15%\" style='border-bottom:solid #ECF0F1 1px;border-right:solid #D8DCE0 1px;padding:8px 10px;'>"
-        f"<p class=MsoNormal align=center style='text-align:center;margin:0;'><b><span style='font-size:10pt;font-family:\"Segoe UI\",sans-serif;color:black'>{tot}</span></b></p></td>"
+        f"<td>{esc(kw)}</td>"
+        f"<td>{hoa}</td>"
+        f"<td>{lc}</td>"
+        f"<td>{tot}</td>"
         "</tr>"
     )
 
-def _replace_detection_rows_in_template(html, row_html):
-    # Find "Detection Match by Chamber" then the next inner table, keep header row, replace the rest.
-    hdr = re.search(r"Detection\s+Match\s+by\s+Chamber", html, flags=re.I)
-    if not hdr:
-        return html
-    m_table_start = re.search(r"<table[^>]*>", html[hdr.end():], flags=re.I | re.S)
-    if not m_table_start:
-        return html
-    tbl_start = hdr.end() + m_table_start.start()
-    m_table_end = re.search(r"</table\s*>", html[tbl_start:], flags=re.I | re.S)
-    if not m_table_end:
-        return html
-    tbl_end = tbl_start + m_table_end.end()
-
-    table_html = html[tbl_start:tbl_end]
-    m_header_row = re.search(r"<tr[^>]*>.*?Keyword.*?</tr\s*>", table_html, flags=re.I | re.S)
-    if not m_header_row:
-        return html
-    before = table_html[:m_header_row.end()]
-    new_table = before + row_html + "</table>"
-    return html[:tbl_start] + new_table + html[tbl_end:]
-
-def _strip_sample_section(html):
-    # Remove the sample block marked in the template
-    pattern = re.compile(r"<!--\s*Sample section to be replaced\s*-->.*?<!--\s*End sample section\s*-->", re.I | re.S)
-    return re.sub(pattern, "", html)
-
-def _inject_sections_after_detection(html, sections_html):
-    hdr = re.search(r"Detection\s+Match\s+by\s+Chamber", html, flags=re.I)
-    if not hdr:
-        return html + sections_html
-    m_table_start = re.search(r"<table[^>]*>", html[hdr.end():], flags=re.I | re.S)
-    if not m_table_start:
-        return html + sections_html
-    tbl_start = hdr.end() + m_table_start.start()
-    m_table_end = re.search(r"</table\s*>", html[tbl_start:], flags=re.I | re.S)
-    if not m_table_end:
-        return html + sections_html
-    insert_at = tbl_start + m_table_end.end()
-    return html[:insert_at] + sections_html + html[insert_at:]
-
-# =============================================================================
-# Per-file sections (“cards”) — Outlook-safe, tight
-# =============================================================================
-
-def _build_file_section_html(filename: str, matches):
+def _build_section_html(filename: str, matches) -> str:
     esc = _html_escape
-    cards = []
-
-    for idx, (_kw_set, excerpt_html, speaker, line_list, _s, _e) in enumerate(matches, 1):
-        line_txt = f"line {line_list[0]}" if len(line_list) == 1 else "lines " + ", ".join(str(n) for n in line_list)
-
-        # Card header + body (top-aligned, pixel line-heights)
-        card = (
-            "<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' "
-            "style='border-collapse:collapse;border:1px solid #D8DCE0;'>"
-            "<tr>"
-            "<td valign='top' style='background:#ECF0F1;border-bottom:1px solid #D8DCE0;padding:4px 8px;"
-            "font-size:0;line-height:0;mso-line-height-rule:exactly;vertical-align:top;'>"
-              "<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='border-collapse:collapse;'>"
-              "<tr>"
-                "<td width='32' align='center' valign='top' style='background:#4A5A6A;border:0;height:18px;vertical-align:top;'>"
-                  "<div style=\"font:bold 10pt 'Segoe UI',sans-serif;color:#FFFFFF;line-height:18px;mso-line-height-rule:exactly;display:block;\">"
-                  f"{idx}</div>"
-                "</td>"
-                "<td width='8' style='font-size:0;line-height:0;vertical-align:top;'>&nbsp;</td>"
-                "<td valign='top' style='vertical-align:top;'>"
-                  "<div style=\"font:bold 10pt 'Segoe UI',sans-serif;color:#24313F;text-transform:uppercase;"
-                  "line-height:15px;mso-line-height-rule:exactly;display:block;\">"
-                  f"{esc(speaker) if speaker else 'UNKNOWN'}</div>"
-                "</td>"
-                "<td align='right' valign='top' style='vertical-align:top;'>"
-                  "<div style=\"font:10pt 'Segoe UI',sans-serif;color:#6A7682;line-height:15px;mso-line-height-rule:exactly;display:block;\">"
-                  f"{line_txt}</div>"
-                "</td>"
-              "</tr>"
-              "</table>"
-            "</td>"
-            "</tr>"
-            "<tr>"
-            "<td valign='top' style='padding:6px 8px;vertical-align:top;'>"
-              "<div style=\"font:10pt 'Segoe UI',sans-serif;color:#1F2A36;line-height:16px;mso-line-height-rule:exactly;display:block;\">"
-              f"{excerpt_html}</div>"
-            "</td>"
-            "</tr>"
-            "</table>"
+    items = []
+    for kw_set, excerpt_html, speaker, line_list, _s, _e in matches:
+        line_txt = (
+            f"line {line_list[0]}"
+            if len(line_list) == 1
+            else "lines " + ", ".join(str(n) for n in line_list)
         )
-        cards.append(card)
-
-    # 2px spacer BETWEEN cards (none after the last)
-    spacer = ("<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0'>"
-              "<tr><td style='height:2px;line-height:2px;font-size:0;'>&nbsp;</td></tr></table>")
-    cards_html = spacer.join(cards)
-
-    section = (
-        "<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='border-collapse:collapse;'>"
-        "<tr>"
-        "<td style='border-left:3px solid #C5A572;background:#F7F9FA;padding:6px 10px;'>"
-        f"<div style=\"font:bold 10pt 'Segoe UI',sans-serif;color:#000;line-height:15px;mso-line-height-rule:exactly;display:block;\">{esc(filename)}</div>"
-        f"<div style=\"font:10pt 'Segoe UI',sans-serif;color:#000;line-height:15px;mso-line-height-rule:exactly;display:block;\">{len(matches)} match(es)</div>"
-        "</td>"
-        "</tr>"
-        "<tr>"
-        "<td style='border:1px solid #D8DCE0;border-top:none;background:#FFFFFF;padding:6px 8px;'>"
-        f"{cards_html}"
-        "</td>"
-        "</tr>"
-        "</table>"
+        kw_txt = ", ".join(sorted(kw_set))
+        items.append(
+            "<div class='match'>"
+            f"<div class='meta'><strong>{esc(speaker or 'UNKNOWN')}</strong> – {esc(kw_txt)} – {line_txt}</div>"
+            f"<div class='excerpt'>{excerpt_html}</div>"
+            "</div>"
+        )
+    return (
+        "<div class='section'>"
+        f"<h3>{esc(filename)} — {len(matches)} match(es)</h3>"
+        + "".join(items)
+        + "</div>"
     )
-    return section
 
 # =============================================================================
 # Build the full HTML
@@ -472,24 +314,10 @@ def _parse_chamber_from_filename(filename: str) -> str:
     return "Unknown"
 
 def build_digest_html(files: list[str], keywords: list[str]):
-    # Load template (Word/Outlook often uses Windows-1252)
-    try:
-        template_html = TEMPLATE_HTML_PATH.read_text(encoding="windows-1252", errors="ignore")
-    except Exception:
-        template_html = TEMPLATE_HTML_PATH.read_text(encoding="utf-8", errors="ignore")
+    template_html = TEMPLATE_HTML_PATH.read_text(encoding="utf-8")
 
-    # Date & small font fix for section title
     run_date = datetime.now().strftime("%d %B %Y")
-    template_html = template_html.replace("[DATE]", run_date)
-    template_html = template_html.replace(
-        '<span style="font-size:12.0pt;color:black">Detection Match by Chamber</span>',
-        '<span style="font-size:12.0pt;font-family:\'Segoe UI\',sans-serif;color:black">Detection Match by Chamber</span>',
-    )
 
-    # Inject MSO CSS reset (safe for Outlook only)
-    template_html = _inject_mso_css_reset(template_html)
-
-    # Collect matches + counts
     counts = {kw: {"House of Assembly": 0, "Legislative Council": 0} for kw in keywords}
     sections, total_matches = [], 0
 
@@ -505,28 +333,19 @@ def build_digest_html(files: list[str], keywords: list[str]):
                 counts.setdefault(kw, {"House of Assembly": 0, "Legislative Council": 0})
                 if chamber in counts[kw]:
                     counts[kw][chamber] += 1
-        sections.append(_build_file_section_html(Path(f).name, matches))
+        sections.append(_build_section_html(Path(f).name, matches))
 
-    # Detection rows
     det_rows = []
     for kw in keywords:
         hoa = counts.get(kw, {}).get("House of Assembly", 0)
-        lc  = counts.get(kw, {}).get("Legislative Council", 0)
+        lc = counts.get(kw, {}).get("Legislative Council", 0)
         det_rows.append(_build_detection_row(kw, hoa, lc, hoa + lc))
-    detection_rows_html = "".join(det_rows)
 
-    # Replace detection rows in template
-    template_html = _replace_detection_rows_in_template(template_html, detection_rows_html)
+    html = template_html.replace("[DATE]", run_date)
+    html = html.replace("[DETECTION_ROWS]", "".join(det_rows))
+    html = html.replace("[SECTIONS]", "".join(sections))
 
-    # Remove sample section, then inject ours after the detection table
-    template_html = _strip_sample_section(template_html)
-    template_html = _inject_sections_after_detection(template_html, "".join(sections))
-
-    # Final whitespace controls: scrub ghost paragraphs then minify inter-tag whitespace
-    template_html = _tighten_outlook_whitespace(template_html)
-    template_html = _minify_inter_tag_whitespace(template_html)
-
-    return template_html, total_matches, counts
+    return html, total_matches, counts
 
 # =============================================================================
 # Sent-log helpers


### PR DESCRIPTION
## Summary
- replace Word-based HTML with a clean UTF-8 template and placeholders
- rebuild digest generation in `send_email.py` to compose detection counts and match sections

## Testing
- `python -m py_compile send_email.py scan_new_transcripts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90a59bbf083328dd85c29133726d7