### PR TITLE
Schedule scan workflow hourly during AEST workday

### DIFF
--- a/.github/workflows/scan_new.yml
+++ b/.github/workflows/scan_new.yml
@@ -3,9 +3,9 @@ name: Scan new Hansard transcripts (by current year)
 on:
   # Run manually when you want to test
   workflow_dispatch: {}
-  # Run daily 5pm Hobart (AEST=UTC+10 → 07:00 UTC). Adjust as needed.
+  # Run hourly between 9am-5pm Hobart (AEST=UTC+10 → 23:00-07:00 UTC). Adjust as needed.
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "0 23,0-7 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Run transcript scanning workflow hourly between 9am-5pm AEST

## Testing
- `python -m unittest` *(fails: No module named 'torch')*
- `pip install torch --quiet` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f73d051883329e093e433cb7fd79